### PR TITLE
WIP, RFC: Bounding sphere decimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Several stop condition are supported:
 ```rust
     let decimation_criteria = ConstantErrorDecimationCriteria::new(0.01f32);
     
-    let mut decimator = EdgeDecimator::new().decimation_criteria(Some(decimation_criteria));
+    let mut decimator = EdgeDecimator::new().decimation_criteria(decimation_criteria);
     decimator.decimate(&mut mesh);
 ```
 
@@ -83,7 +83,7 @@ Several stop condition are supported:
 
     let criteria = BoundingSphereDecimationCriteria::new(origin, radii_error_map);
 
-    let mut decimator = EdgeDecimator::new().decimation_criteria(Some(criteria));
+    let mut decimator = EdgeDecimator::new().decimation_criteria(criteria);
     decimator.decimate(&mut mesh);
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Several stop condition are supported:
 
 ### Example
 ```rust
-    let decimation_criteria = ConstantErrorDecimationCriteria::new(0.01f32);
-    
-    let mut decimator = EdgeDecimator::new().decimation_criteria(decimation_criteria);
+    let mut decimator = EdgeDecimator::new()
+        .decimation_criteria(ConstantErrorDecimationCriteria::new(0.0005))
+        .min_faces_count(Some(10000));
     decimator.decimate(&mut mesh);
 ```
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,24 @@ Several stop condition are supported:
 
 ### Example
 ```rust
-    let decimation_criterion = ConstantErrorDecimationCriterion::new(0.01f32);
+    let decimation_criteria = ConstantErrorDecimationCriteria::new(0.01f32);
     
-    let mut decimator = EdgeDecimator::new().edge_decimation_criterion(Some(decimation_criterion));
+    let mut decimator = EdgeDecimator::new().decimation_criteria(Some(decimation_criteria));
+    decimator.decimate(&mut mesh);
+```
+
+### Bounded Sphere Example
+```rust
+    let origin = Point3::<f32>::origin();
+    let radii_error_map = vec![
+        (10.0f32, 0.0001f32),
+        (15.0f32, 0.05f32),
+        (40.0f32, 0.8f32),
+    ];
+
+    let criteria = BoundingSphereDecimationCriteria::new(origin, radii_error_map);
+
+    let mut decimator = EdgeDecimator::new().decimation_criteria(Some(criteria));
     decimator.decimate(&mut mesh);
 ```
 

--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ Several stop condition are supported:
 
 ### Example
 ```rust
- let mut decimator = EdgeDecimator::new()
-     .max_error(Some(0.0005))
-     .min_faces_count(Some(10000));
- decimator.decimate(&mut mesh);
+let max_error = ConstantMaxError::new(0.0005);
+
+let mut decimator = EdgeDecimator::new()
+    .max_error(Some(max_error))
+    .min_faces_count(Some(10000));
+decimator.decimate(&mut mesh);
 ```
 
 ## 2D triangulation

--- a/README.md
+++ b/README.md
@@ -60,17 +60,16 @@ This library implements incremental edge decimation algorithm. On each iteration
 Several stop condition are supported:
 * *Max error* - algorithm stops when collapse lowest cost is bigger than given value
 * *Min faces count* - algorithm stops when faces count drops below given value
+* *Bounding sphere* - adaptive error algorithm based upon distance from a point. Useful for LOD mesh decimation.
 
 ![image](https://user-images.githubusercontent.com/48240075/192602743-59d91022-4eb1-4aef-b7af-5f0b3cdcefb5.png)
 
 ### Example
 ```rust
-let max_error = ConstantMaxError::new(0.0005);
-
-let mut decimator = EdgeDecimator::new()
-    .max_error(Some(max_error))
-    .min_faces_count(Some(10000));
-decimator.decimate(&mut mesh);
+    let decimation_criterion = ConstantErrorDecimationCriterion::new(0.01f32);
+    
+    let mut decimator = EdgeDecimator::new().edge_decimation_criterion(Some(decimation_criterion));
+    decimator.decimate(&mut mesh);
 ```
 
 ## 2D triangulation

--- a/examples/bsphere_simplification.rs
+++ b/examples/bsphere_simplification.rs
@@ -23,9 +23,9 @@ fn main() {
 
     let origin = Point3::<f32>::origin();
     let radii_error_map = vec![
-        (10.0f32, 0.0001f32),
-        (15.0f32, 0.05f32),
-        (40.0f32, 0.8f32),
+        (5.0f32, 0.0001f32),
+        (10.0f32, 0.001f32),
+        (15.0f32, 0.8f32),
     ];
 
     let criteria = BoundingSphereDecimationCriteria::new(origin, radii_error_map);

--- a/examples/bsphere_simplification.rs
+++ b/examples/bsphere_simplification.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+
+use baby_shark::{
+    decimation::{
+        edge_decimation::{BoundingSphere, BoundingSphereMaxError},
+        prelude::EdgeDecimator,
+    },
+    io::stl::{StlReader, StlWriter},
+    mesh::corner_table::prelude::CornerTableF,
+};
+
+use nalgebra::Point3;
+
+fn main() {
+    let mut reader = StlReader::new();
+    let mut args = std::env::args();
+    args.next();
+    let path = args.next().expect("Enter an input file");
+    let output = args.next().expect("Enter an output file");
+
+    let mut mesh: CornerTableF = reader
+        .read_stl_from_file(Path::new(&path))
+        .expect("Read mesh from STL");
+
+    let origin = Point3::<f32>::new(0.0, 0.0, 0.0);
+    let origin2 = origin.clone();
+    let bounding_spheres = vec![
+        (
+            BoundingSphere {
+                origin,
+                radius: 5.0,
+            },
+            0.0001,
+        ),
+        (
+            BoundingSphere {
+                origin: origin2,
+                radius: 15.0,
+            },
+            0.001,
+        ),
+        (
+            BoundingSphere {
+                origin: origin2,
+                radius: 40.0,
+            },
+            0.8,
+        ),
+    ];
+
+    let max_error = BoundingSphereMaxError::new(bounding_spheres);
+
+    let mut decimator = EdgeDecimator::new().max_error(max_error);
+    decimator.decimate(&mut mesh);
+
+    let writer = StlWriter::new();
+    writer
+        .write_stl_to_file(&mesh, Path::new(&output))
+        .expect("Save mesh to STL");
+}

--- a/examples/bsphere_simplification.rs
+++ b/examples/bsphere_simplification.rs
@@ -21,16 +21,16 @@ fn main() {
         .read_stl_from_file(Path::new(&path))
         .expect("Read mesh from STL");
 
-    let origin = Point3::<f32>::new(5.0, 0.0, 0.0);
-    let radii_errors = vec![
+    let origin = Point3::<f32>::origin();
+    let radii_error_map = vec![
         (10.0f32, 0.0001f32),
-        (15.0f32, 0.8f32),
+        (15.0f32, 0.05f32),
         (40.0f32, 0.8f32),
     ];
 
-    let criterion = BoundingSphereDecimationCriteria::new(origin, radii_errors);
+    let criteria = BoundingSphereDecimationCriteria::new(origin, radii_error_map);
 
-    let mut decimator = EdgeDecimator::new().edge_decimation_criterion(Some(criterion));
+    let mut decimator = EdgeDecimator::new().decimation_criteria(Some(criteria));
     decimator.decimate(&mut mesh);
 
     let writer = StlWriter::new();

--- a/examples/bsphere_simplification.rs
+++ b/examples/bsphere_simplification.rs
@@ -23,28 +23,18 @@ fn main() {
         .expect("Read mesh from STL");
 
     let origin = Point3::<f32>::new(0.0, 0.0, 0.0);
-    let origin2 = origin.clone();
     let bounding_spheres = vec![
         (
-            BoundingSphere {
-                origin,
-                radius: 5.0,
-            },
-            0.0001,
+            BoundingSphere::new(origin, 5.0f32),
+            0.0001f32,
         ),
         (
-            BoundingSphere {
-                origin: origin2,
-                radius: 15.0,
-            },
-            0.001,
+            BoundingSphere::new(origin, 15.0f32),
+            0.001f32,
         ),
         (
-            BoundingSphere {
-                origin: origin2,
-                radius: 40.0,
-            },
-            0.8,
+            BoundingSphere::new(origin, 40.0f32),
+            0.8f32,
         ),
     ];
 

--- a/examples/bsphere_simplification.rs
+++ b/examples/bsphere_simplification.rs
@@ -50,7 +50,7 @@ fn main() {
 
     let max_error = BoundingSphereMaxError::new(bounding_spheres);
 
-    let mut decimator = EdgeDecimator::new().max_error(max_error);
+    let mut decimator = EdgeDecimator::new().max_error(Some(max_error));
     decimator.decimate(&mut mesh);
 
     let writer = StlWriter::new();

--- a/examples/bsphere_simplification.rs
+++ b/examples/bsphere_simplification.rs
@@ -30,7 +30,7 @@ fn main() {
 
     let criteria = BoundingSphereDecimationCriteria::new(origin, radii_error_map);
 
-    let mut decimator = EdgeDecimator::new().decimation_criteria(Some(criteria));
+    let mut decimator = EdgeDecimator::new().decimation_criteria(criteria);
     decimator.decimate(&mut mesh);
 
     let writer = StlWriter::new();

--- a/examples/bsphere_simplification.rs
+++ b/examples/bsphere_simplification.rs
@@ -2,8 +2,7 @@ use std::path::Path;
 
 use baby_shark::{
     decimation::{
-        edge_decimation::{BoundingSphere, BoundingSphereMaxError},
-        prelude::EdgeDecimator,
+        prelude::EdgeDecimator, edge_decimation::BoundingSphereDecimationCriteria,
     },
     io::stl::{StlReader, StlWriter},
     mesh::corner_table::prelude::CornerTableF,
@@ -22,25 +21,16 @@ fn main() {
         .read_stl_from_file(Path::new(&path))
         .expect("Read mesh from STL");
 
-    let origin = Point3::<f32>::new(0.0, 0.0, 0.0);
-    let bounding_spheres = vec![
-        (
-            BoundingSphere::new(origin, 5.0f32),
-            0.0001f32,
-        ),
-        (
-            BoundingSphere::new(origin, 15.0f32),
-            0.001f32,
-        ),
-        (
-            BoundingSphere::new(origin, 40.0f32),
-            0.8f32,
-        ),
+    let origin = Point3::<f32>::new(5.0, 0.0, 0.0);
+    let radii_errors = vec![
+        (10.0f32, 0.0001f32),
+        (15.0f32, 0.8f32),
+        (40.0f32, 0.8f32),
     ];
 
-    let max_error = BoundingSphereMaxError::new(bounding_spheres);
+    let criterion = BoundingSphereDecimationCriteria::new(origin, radii_errors);
 
-    let mut decimator = EdgeDecimator::new().max_error(Some(max_error));
+    let mut decimator = EdgeDecimator::new().edge_decimation_criterion(Some(criterion));
     decimator.decimate(&mut mesh);
 
     let writer = StlWriter::new();

--- a/examples/simplification.rs
+++ b/examples/simplification.rs
@@ -12,7 +12,7 @@ fn main() {
 
     let decimation_criteria = ConstantErrorDecimationCriteria::new(0.01f32);
     
-    let mut decimator = EdgeDecimator::new().decimation_criteria(Some(decimation_criteria));
+    let mut decimator = EdgeDecimator::new().decimation_criteria(decimation_criteria);
     decimator.decimate(&mut mesh);
 
     let writer = StlWriter::new();

--- a/examples/simplification.rs
+++ b/examples/simplification.rs
@@ -2,15 +2,17 @@ use std::path::Path;
 
 use baby_shark::{
     io::stl::{StlReader, StlWriter}, 
-    decimation::prelude::EdgeDecimator, 
+    decimation::{prelude::EdgeDecimator, edge_decimation::ConstantMaxError}, 
     mesh::corner_table::prelude::CornerTableF
 };
 
 fn main() {
     let mut reader = StlReader::new();
     let mut mesh: CornerTableF = reader.read_stl_from_file(Path::new("./test_files/violin.stl")).expect("Read mesh from STL");
+
+    let max_error = ConstantMaxError::new(0.01f32);
     
-    let mut decimator = EdgeDecimator::new().max_error(Some(0.01f32));
+    let mut decimator = EdgeDecimator::new().max_error(max_error);
     decimator.decimate(&mut mesh);
 
     let writer = StlWriter::new();

--- a/examples/simplification.rs
+++ b/examples/simplification.rs
@@ -10,9 +10,9 @@ fn main() {
     let mut reader = StlReader::new();
     let mut mesh: CornerTableF = reader.read_stl_from_file(Path::new("./test_files/violin.stl")).expect("Read mesh from STL");
 
-    let decimation_criterion = ConstantErrorDecimationCriteria::new(0.01f32);
+    let decimation_criteria = ConstantErrorDecimationCriteria::new(0.01f32);
     
-    let mut decimator = EdgeDecimator::new().edge_decimation_criterion(Some(decimation_criterion));
+    let mut decimator = EdgeDecimator::new().decimation_criteria(Some(decimation_criteria));
     decimator.decimate(&mut mesh);
 
     let writer = StlWriter::new();

--- a/examples/simplification.rs
+++ b/examples/simplification.rs
@@ -12,7 +12,7 @@ fn main() {
 
     let max_error = ConstantMaxError::new(0.01f32);
     
-    let mut decimator = EdgeDecimator::new().max_error(max_error);
+    let mut decimator = EdgeDecimator::new().max_error(Some(max_error));
     decimator.decimate(&mut mesh);
 
     let writer = StlWriter::new();

--- a/examples/simplification.rs
+++ b/examples/simplification.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use baby_shark::{
     io::stl::{StlReader, StlWriter}, 
-    decimation::{prelude::EdgeDecimator, edge_decimation::ConstantMaxError}, 
+    decimation::{prelude::EdgeDecimator, edge_decimation::ConstantErrorDecimationCriteria}, 
     mesh::corner_table::prelude::CornerTableF
 };
 
@@ -10,9 +10,9 @@ fn main() {
     let mut reader = StlReader::new();
     let mut mesh: CornerTableF = reader.read_stl_from_file(Path::new("./test_files/violin.stl")).expect("Read mesh from STL");
 
-    let max_error = ConstantMaxError::new(0.01f32);
+    let decimation_criterion = ConstantErrorDecimationCriteria::new(0.01f32);
     
-    let mut decimator = EdgeDecimator::new().max_error(Some(max_error));
+    let mut decimator = EdgeDecimator::new().edge_decimation_criterion(Some(decimation_criterion));
     decimator.decimate(&mut mesh);
 
     let writer = StlWriter::new();

--- a/src/decimation/edge_decimation.rs
+++ b/src/decimation/edge_decimation.rs
@@ -401,7 +401,9 @@ impl<TMesh: Mesh> BoundingSphereMaxError<TMesh> {
         Self { bounding_spheres }
     }
 }
+
 impl<TMesh: Mesh> MaxError<TMesh> for BoundingSphereMaxError<TMesh> {
+    #[inline]
     fn max_error(
         &self,
         mesh: &TMesh,
@@ -425,7 +427,7 @@ where
     fn default() -> Self {
         let origin = Point3::<TMesh::ScalarType>::origin();
         let radius = TMesh::ScalarType::max_value();
-        let bounding_sphere = BoundingSphere::<TMesh> { origin, radius };
+        let bounding_sphere = BoundingSphere::<TMesh>::new(origin, radius);
         let bounding_spheres = vec![(bounding_sphere, cast(0.001).unwrap())];
         Self { bounding_spheres }
     }
@@ -434,13 +436,25 @@ where
 pub struct BoundingSphere<TMesh: Mesh> {
     pub origin: Point3<TMesh::ScalarType>,
     pub radius: TMesh::ScalarType,
+    radius_squared: TMesh::ScalarType,
+}
+
+impl <TMesh: Mesh> BoundingSphere<TMesh> {
+    pub fn new(origin: Point3<TMesh::ScalarType>, radius: TMesh::ScalarType) -> Self {
+        Self {
+            origin,
+            radius,
+            radius_squared: radius * radius,
+        }
+    }
 }
 
 impl<TMesh> BoundingSphere<TMesh>
 where
     TMesh: Mesh,
 {
+    #[inline]
     pub fn contains_point(&self, point: &Point3<TMesh::ScalarType>) -> bool {
-        nalgebra::distance(&self.origin, point) <= self.radius
+        nalgebra::distance_squared(&self.origin, point) <= self.radius_squared
     }
 }

--- a/src/decimation/edge_decimation.rs
+++ b/src/decimation/edge_decimation.rs
@@ -398,8 +398,8 @@ pub struct BoundingSphereDecimationCriteria<TMesh: Mesh> {
 
 impl<TMesh: Mesh> BoundingSphereDecimationCriteria<TMesh> {
     pub fn new(origin: Point3::<TMesh::ScalarType>, radii_error_map: Vec<(TMesh::ScalarType, TMesh::ScalarType)>) -> Self {
-        let radii_sq_error = radii_error_map.into_iter().map(|(r, e)| (r * r, e)).collect();
-        Self { origin, radii_sq_error_map: radii_sq_error }
+        let radii_sq_error_map = radii_error_map.into_iter().map(|(r, e)| (r * r, e)).collect();
+        Self { origin, radii_sq_error_map }
     }
 
 }
@@ -412,8 +412,9 @@ impl<TMesh: Mesh> EdgeDecimationCriteria<TMesh> for BoundingSphereDecimationCrit
             nalgebra::distance_squared(&self.origin, &edge_positions.0 ) < *radius_sq 
             || nalgebra::distance_squared(&self.origin, &edge_positions.1) < *radius_sq);
         
-        let max_error = max_error.unwrap_or(self.radii_sq_error_map.last().unwrap());
-        return error < max_error.1;
+        let max_error = max_error.unwrap_or(self.radii_sq_error_map.last().unwrap()).1;
+        
+        return error < max_error;
     }
 
 }

--- a/src/decimation/prelude.rs
+++ b/src/decimation/prelude.rs
@@ -1,4 +1,4 @@
 use super::edge_decimation::{IncrementalDecimator, QuadricError};
 
 /// Mesh decimation through edge collapsing. For details see [IncrementalDecimator].
-pub type EdgeDecimator<TMesh, TMaxError> = IncrementalDecimator<TMesh, QuadricError<TMesh>, TMaxError>;
+pub type EdgeDecimator<TMesh, TEdgeDecimationCriteria> = IncrementalDecimator<TMesh, QuadricError<TMesh>, TEdgeDecimationCriteria>;

--- a/src/decimation/prelude.rs
+++ b/src/decimation/prelude.rs
@@ -1,4 +1,4 @@
 use super::edge_decimation::{IncrementalDecimator, QuadricError};
 
 /// Mesh decimation through edge collapsing. For details see [IncrementalDecimator].
-pub type EdgeDecimator<TMesh> = IncrementalDecimator<TMesh, QuadricError<TMesh>>;
+pub type EdgeDecimator<TMesh, TMaxError> = IncrementalDecimator<TMesh, QuadricError<TMesh>, TMaxError>;

--- a/src/reeb_graph/ordered_triangle.rs
+++ b/src/reeb_graph/ordered_triangle.rs
@@ -211,6 +211,7 @@ impl<TMesh: Mesh + VertexProperties> PartialOrd for OrderedEdge<TMesh> {
 ///
 /// Ordered triangle
 /// 
+#[allow(unused)]
 pub struct OrderedTriangle<TMesh: Mesh> {
     e1: OrderedEdge<TMesh>,
     e2: OrderedEdge<TMesh>,
@@ -221,6 +222,7 @@ pub struct OrderedTriangle<TMesh: Mesh> {
     top_vertex: OrderedVertex<TMesh>
 }
 
+#[allow(unused)]
 impl<TMesh: Mesh + TopologicalMesh + VertexProperties> OrderedTriangle<TMesh> {
     pub fn from_face(
         face: &TMesh::FaceDescriptor, 


### PR DESCRIPTION
This adds LOD decimation based on bounding spheres. This works for me, I wrote it about a week ago, and I just wanted to show it, in case you find the use case intriguing.

I'm not 100% sure about the implementation, and that I got the the generic trait bounds correct.

One thing I thought of was, instead of having nested bounding spheres, have an origin, radius, initial error, and error increment per distance unit, for continuous LOD.

Anyway, thanks for the cool library, and it was pretty nice how easy it was to add this functionality, without it having necessarily being a use case you had envisioned. :+1: 