### PR TITLE
add clone_remap trait fn, and implementer on CornerTable

### DIFF
--- a/src/mesh/corner_table/table.rs
+++ b/src/mesh/corner_table/table.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, fmt::Display};
 use nalgebra::{Point3, Vector3};
 use tabled::Table;
-use crate::{mesh::traits::{Mesh, TopologicalMesh, MeshMarker}, geometry::traits::RealNumber};
+use crate::{mesh::traits::{Mesh, TopologicalMesh, MeshMarker}, geometry::traits::RealNumber, algo::merge_points::merge_points};
 use self::helpers::Edge;
 use super::{
     traversal::{
@@ -251,6 +251,17 @@ impl<TScalar: RealNumber> Mesh for CornerTable<TScalar> {
         }
 
         return Some(sum.normalize());
+    }
+
+    fn clone_remap(&self) -> Self {
+        let vertices: Vec<Point3<Self::ScalarType>> = self.faces().map(|face| {
+            let tri = self.face_positions(&face);
+            [tri.p1().clone(), tri.p2().clone(), tri.p3().clone()]
+        }).flatten().collect();
+
+        let indexed = merge_points(&vertices);
+
+        Self::from_vertices_and_indices(&indexed.points, &indexed.indices)
     }
 }
 

--- a/src/mesh/polygon_soup/data_structure.rs
+++ b/src/mesh/polygon_soup/data_structure.rs
@@ -95,4 +95,8 @@ impl<TScalar: RealNumber> Mesh for PolygonSoup<TScalar> {
     fn face_vertices(&self, _face: &Self::FaceDescriptor) -> (Self::VertexDescriptor, Self::VertexDescriptor, Self::VertexDescriptor) {
         todo!()
     }
+
+    fn clone_remap(&self) -> Self {
+        todo!()
+    }
 }

--- a/src/mesh/traits.rs
+++ b/src/mesh/traits.rs
@@ -86,6 +86,9 @@ pub trait Mesh {
         let (v1, v2) = self.edge_positions(edge);
         return (v1 - v2).norm_squared();
     }
+
+    /// Clone mesh, and remapping points and indices
+    fn clone_remap(&self) -> Self;
 }
 
 ///


### PR DESCRIPTION
adds a clone_remap trait to Mesh.

I added this to the `Mesh` trait, as the generic traits were a little tricky on `EditableMesh`, but I can look further and add it to `EditableMesh` trait instead. It kind of seems to be conceptually a better place on the `Mesh` anyway though, to my mind.