### PR TITLE
Corner Table `from_iters`

### DIFF
--- a/src/io/stl.rs
+++ b/src/io/stl.rs
@@ -74,7 +74,7 @@ impl StlReader {
                 .collect();
         
         // Create mesh
-        Ok(TMesh::from_vertices_and_indices(&vertices, &merged_vertices.indices))
+        Ok(TMesh::from_slices(&vertices, &merged_vertices.indices))
     }
 
     fn read_face<TBuffer: Read>(&mut self, reader: &mut BufReader<TBuffer>) -> io::Result<()> {

--- a/src/mesh/builder.rs
+++ b/src/mesh/builder.rs
@@ -24,5 +24,5 @@ pub fn cube<T: Mesh>(origin: Vec3<T::ScalarType>, x_size: T::ScalarType, y_size:
         1, 5, 6, 1, 6, 2
     ];
 
-    T::from_vertices_and_indices(&vertices, &faces)
+    T::from_slices(&vertices, &faces)
 }

--- a/src/mesh/corner_table/test_helpers.rs
+++ b/src/mesh/corner_table/test_helpers.rs
@@ -11,7 +11,7 @@ pub fn create_unit_square_mesh() -> CornerTableF {
 
     let indices = vec![0, 1, 2, 2, 3, 0];
 
-    CornerTableF::from_vertices_and_indices(&vertices, &indices)
+    CornerTableF::from_slices(&vertices, &indices)
 }
 
 pub fn create_unit_cross_square_mesh() -> CornerTableF {
@@ -30,7 +30,7 @@ pub fn create_unit_cross_square_mesh() -> CornerTableF {
         3, 0, 4
     ];
 
-    CornerTableF::from_vertices_and_indices(&vertices, &indices)
+    CornerTableF::from_slices(&vertices, &indices)
 }
 
 pub fn create_single_face_mesh() -> CornerTableF {
@@ -42,7 +42,7 @@ pub fn create_single_face_mesh() -> CornerTableF {
 
     let indices = vec![0, 1, 2];
 
-    CornerTableF::from_vertices_and_indices(&vertices, &indices)
+    CornerTableF::from_slices(&vertices, &indices)
 }
 
 // Mesh with vertices around edges vertices
@@ -73,7 +73,7 @@ pub fn create_collapse_edge_sample_mesh1() -> CornerTableF {
         7, 0, 8
     ];
 
-    CornerTableF::from_vertices_and_indices(&vertices, &indices)
+    CornerTableF::from_slices(&vertices, &indices)
 }
 
 // Mesh with vertices around one vertex of edge
@@ -97,7 +97,7 @@ pub fn create_collapse_edge_sample_mesh2() -> CornerTableF {
         5, 0, 6
     ];
 
-    CornerTableF::from_vertices_and_indices(&vertices, &indices)
+    CornerTableF::from_slices(&vertices, &indices)
 }
 
 // Half star
@@ -116,7 +116,7 @@ pub fn create_collapse_edge_sample_mesh3() -> CornerTableF {
         2, 3, 4
     ];
 
-    CornerTableF::from_vertices_and_indices(&vertices, &indices)
+    CornerTableF::from_slices(&vertices, &indices)
 }
 
 pub fn create_flip_edge_sample_mesh() -> CornerTableF {
@@ -140,7 +140,7 @@ pub fn create_flip_edge_sample_mesh() -> CornerTableF {
         0, 5, 1
     ];
 
-    CornerTableF::from_vertices_and_indices(&vertices, &indices)
+    CornerTableF::from_slices(&vertices, &indices)
 }
 
 pub fn assert_mesh_eq(mesh: &CornerTableF, expected_corners: &Vec<Corner>, expected_vertices: &Vec<VertexF>) {

--- a/src/mesh/polygon_soup/data_structure.rs
+++ b/src/mesh/polygon_soup/data_structure.rs
@@ -49,16 +49,28 @@ impl<TScalar: RealNumber> Mesh for PolygonSoup<TScalar> {
     type VerticesIter<'iter> = VerticesIter<'iter, TScalar>;
     type EdgesIter<'iter> = EdgesIter<'iter, TScalar>;
 
-    fn from_vertices_and_indices(vertices: &[Vec3<Self::ScalarType>], faces: &[usize]) -> Self {
-        let mut soup = Vec::with_capacity(faces.len());
+    fn from_iters(vertices: impl Iterator<Item = Vec3<Self::ScalarType>>, faces: impl Iterator<Item = usize>) -> Self {
+        let num_faces = faces.size_hint().1.unwrap_or(0);
+        let mut soup = Vec::with_capacity(num_faces * 3);
+        let vertices: Vec<_> = vertices.collect();
 
         for vertex_index in faces {
-            soup.push(vertices[*vertex_index]);
+            soup.push(vertices[vertex_index]);
         }
 
         Self {
             vertices: soup
         }
+    }
+
+    fn from_slices(vertices: &[Vec3<Self::ScalarType>], faces: &[usize]) -> Self where Self: Sized {
+        let mut soup = Vec::with_capacity(faces.len());
+
+        for &vertex_index in faces {
+            soup.push(vertices[vertex_index]);
+        }
+        
+        Self { vertices: soup }
     }
 
     #[inline]

--- a/src/mesh/traits.rs
+++ b/src/mesh/traits.rs
@@ -33,7 +33,7 @@ pub trait Mesh {
     type EdgesIter<'iter>: Iterator<Item = Self::EdgeDescriptor> where Self: 'iter;
 
     /// Creates mesh from vertices and face indices
-    fn from_vertices_and_indices(vertices: &[Vec3<Self::ScalarType>], faces: &[usize]) -> Self;
+    fn from_iters(vertices: impl Iterator<Item = Vec3<Self::ScalarType>>, faces: impl Iterator<Item = usize>) -> Self;
 
     /// Iterator over mesh faces
     fn faces(&self) -> Self::FacesIter<'_>;
@@ -53,6 +53,12 @@ pub trait Mesh {
     fn vertex_position(&self, vertex: &Self::VertexDescriptor) -> &Vec3<Self::ScalarType>;
     /// Returns vertex normal (average of one-ring face normals)
     fn vertex_normal(&self, vertex: &Self::VertexDescriptor) -> Option<Vec3<Self::ScalarType>>;
+
+    /// Creates mesh from vertices and face indices saved in slices
+    #[inline]
+    fn from_slices(vertices: &[Vec3<Self::ScalarType>], faces: &[usize]) -> Self where Self: Sized {
+        Self::from_iters(vertices.iter().cloned(), faces.iter().cloned())
+    }
 
     /// Returns positions of face vertices in ccw order
     #[allow(clippy::type_complexity)]

--- a/src/remeshing/voxel.rs
+++ b/src/remeshing/voxel.rs
@@ -73,7 +73,7 @@ impl VoxelRemesher {
         };
 
         let indexed_faces = merge_points(&faces);
-        let mesh = T::from_vertices_and_indices(&indexed_faces.points, &indexed_faces.indices);
+        let mesh = T::from_slices(&indexed_faces.points, &indexed_faces.indices);
 
         Some(mesh)
     }

--- a/src/spatial_partitioning/grid.rs
+++ b/src/spatial_partitioning/grid.rs
@@ -249,7 +249,7 @@ mod tests {
     fn test_grid_creation_zero_volume_cases() {
         let expected_cell_size = Vec3f::new(0.793700516, 0.793700516, 0.793700516);
 
-        let x_0 = CornerTableF::from_vertices_and_indices(
+        let x_0 = CornerTableF::from_slices(
             &vec![
                 Vec3f::new(0.0, 0.0, 0.0),
                 Vec3f::new(0.0, 1.0, 0.0),
@@ -262,7 +262,7 @@ mod tests {
         let grid = Grid::from_mesh(&x_0);
         assert!((expected_cell_size - grid.cell_size).norm() < 1e-6);
 
-        let y_0 = CornerTableF::from_vertices_and_indices(
+        let y_0 = CornerTableF::from_slices(
             &vec![
                 Vec3f::new(0.0, 0.0, 0.0),
                 Vec3f::new(1.0, 0.0, 0.0),
@@ -275,7 +275,7 @@ mod tests {
         let grid = Grid::from_mesh(&y_0);
         assert!((expected_cell_size - grid.cell_size).norm() < 1e-6);
 
-        let z_0 = CornerTableF::from_vertices_and_indices(
+        let z_0 = CornerTableF::from_slices(
             &vec![
                 Vec3f::new(0.0, 0.0, 0.0),
                 Vec3f::new(1.0, 0.0, 0.0),


### PR DESCRIPTION
Adds method to construct corner table from iterators.