### PR TITLE
Use u32 for corner table ids

### DIFF
--- a/examples/incremental_remeshing.rs
+++ b/examples/incremental_remeshing.rs
@@ -15,7 +15,7 @@ fn main() {
     let remesher = IncrementalRemesher::default();
 
     let now = std::time::Instant::now();
-    remesher.remesh(&mut mesh, 0.5f32);
+    remesher.remesh(&mut mesh, 0.3f32);
     println!("Remeshing took: {:?}", now.elapsed());
 
     let writer = StlWriter::new();

--- a/examples/incremental_remeshing.rs
+++ b/examples/incremental_remeshing.rs
@@ -15,7 +15,7 @@ fn main() {
     let remesher = IncrementalRemesher::default();
 
     let now = std::time::Instant::now();
-    remesher.remesh(&mut mesh, 0.3f32);
+    remesher.remesh(&mut mesh, 0.5f32);
     println!("Remeshing took: {:?}", now.elapsed());
 
     let writer = StlWriter::new();

--- a/src/mesh/corner_table/corner.rs
+++ b/src/mesh/corner_table/corner.rs
@@ -9,12 +9,12 @@ pub struct CornerId(u32);
 
 impl CornerId {
     #[inline]
-    pub(super) fn new(index: usize) -> Self {
+    pub(super) fn new(index: u32) -> Self {
         debug_assert!(
-            index < u32::MAX as usize,
+            index != u32::MAX,
             "CornerId cannot be created with invalid index"
         );
-        Self(index as u32)
+        Self(index)
     }
 
     #[inline]
@@ -52,7 +52,7 @@ impl CornerId {
 
     #[inline]
     pub fn face(&self) -> FaceId {
-        FaceId::new((self.0 / 3) as usize)
+        FaceId::new(self.0 / 3)
     }
 }
 

--- a/src/mesh/corner_table/corner.rs
+++ b/src/mesh/corner_table/corner.rs
@@ -5,31 +5,31 @@ use std::fmt::Debug;
 use std::ops::{Index, IndexMut};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CornerId(usize);
+pub struct CornerId(u32);
 
 impl CornerId {
     #[inline]
     pub(super) fn new(index: usize) -> Self {
         debug_assert!(
-            index != usize::MAX,
+            index < u32::MAX as usize,
             "CornerId cannot be created with invalid index"
         );
-        Self(index)
+        Self(index as u32)
     }
 
     #[inline]
     pub(super) fn is_valid(&self) -> bool {
-        self.0 != usize::MAX
+        self.0 != u32::MAX
     }
 
     #[inline]
     pub(super) fn from_option(corner: Option<CornerId>) -> Self {
-        corner.unwrap_or(Self(usize::MAX))
+        corner.unwrap_or(Self(u32::MAX))
     }
     
     #[inline]
     pub(super) fn index(&self) -> usize {
-        self.0
+        self.0 as usize
     }
 
     #[inline]
@@ -52,7 +52,7 @@ impl CornerId {
 
     #[inline]
     pub fn face(&self) -> FaceId {
-        FaceId::new(self.0 / 3)
+        FaceId::new((self.0 / 3) as usize)
     }
 }
 
@@ -123,7 +123,7 @@ impl<TScalar: RealNumber> Index<CornerId> for CornerTable<TScalar> {
     #[inline]
     fn index(&self, index: CornerId) -> &Self::Output {
         assert!(index.is_valid());
-        &self.corners[index.0]
+        &self.corners[index.0 as usize]
     }
 }
 
@@ -131,7 +131,7 @@ impl<TScalar: RealNumber> IndexMut<CornerId> for CornerTable<TScalar> {
     #[inline]
     fn index_mut(&mut self, index: CornerId) -> &mut Self::Output {
         assert!(index.is_valid());
-        &mut self.corners[index.0]
+        &mut self.corners[index.0 as usize]
     }
 }
 

--- a/src/mesh/corner_table/create.rs
+++ b/src/mesh/corner_table/create.rs
@@ -40,14 +40,14 @@ impl<TScalar: RealNumber> CornerTable<TScalar> {
         let idx = self.vertices.len();
         let vertex = Vertex::new(CornerId::from_option(corner), position);
         self.vertices.push(vertex);
-        VertexId::new(idx)
+        VertexId::new(u32::try_from(idx).expect("number of vertices is too big"))
     }
 
     #[inline]
     pub(super) fn create_corner(&mut self, vertex: VertexId) -> (CornerId, &mut Corner) {
         let idx = self.corners.len();
         self.corners.push(Corner::new(None, vertex));
-        (CornerId::new(idx), &mut self.corners[idx])
+        (CornerId::new(u32::try_from(idx).expect("number of faces is too big")), &mut self.corners[idx])
     }
 
     fn corner_from(
@@ -101,9 +101,9 @@ impl<S: RealNumber> FromIndexed for CornerTable<S> {
         let mut vertex_corners = HashMap::<VertexId, BTreeSet<CornerId>>::with_capacity(num_vertices);
 
         loop {
-            let Some(v1_index) = faces.next().map(|i| VertexId::new(i)) else { break; };
-            let Some(v2_index) = faces.next().map(|i| VertexId::new(i)) else { break; };
-            let Some(v3_index) = faces.next().map(|i| VertexId::new(i)) else { break; };
+            let Some(v1_index) = faces.next().map(|i| VertexId::new(i as u32)) else { break; };
+            let Some(v2_index) = faces.next().map(|i| VertexId::new(i as u32)) else { break; };
+            let Some(v3_index) = faces.next().map(|i| VertexId::new(i as u32)) else { break; };
 
             let edge1 = helpers::Edge::new(v2_index, v3_index);
             let edge2 = helpers::Edge::new(v3_index, v1_index);

--- a/src/mesh/corner_table/face.rs
+++ b/src/mesh/corner_table/face.rs
@@ -9,21 +9,21 @@ impl FaceId {
     pub fn corners(&self) -> (CornerId, CornerId, CornerId) {
         let base = self.0 * 3;
         (
-            CornerId::new(base as usize),
-            CornerId::new((base + 1) as usize),
-            CornerId::new((base + 2) as usize),
+            CornerId::new(base),
+            CornerId::new(base + 1),
+            CornerId::new(base + 2),
         )
     }
 
     /// Returns the first corner of the face.
     #[inline]
     pub fn corner(&self) -> CornerId {
-        CornerId::new((self.0 * 3) as usize)
+        CornerId::new(self.0 * 3)
     }
 
     #[inline]
-    pub(super) fn new(index: usize) -> Self {
-        Self(index as u32)
+    pub(super) fn new(index: u32) -> Self {
+        Self(index)
     }
 }
 

--- a/src/mesh/corner_table/face.rs
+++ b/src/mesh/corner_table/face.rs
@@ -2,28 +2,28 @@ use super::*;
 use crate::{geometry::primitives::triangle3::Triangle3, helpers::aliases::Vec3};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FaceId(usize);
+pub struct FaceId(u32);
 
 impl FaceId {
     #[inline]
     pub fn corners(&self) -> (CornerId, CornerId, CornerId) {
         let base = self.0 * 3;
         (
-            CornerId::new(base),
-            CornerId::new(base + 1),
-            CornerId::new(base + 2),
+            CornerId::new(base as usize),
+            CornerId::new((base + 1) as usize),
+            CornerId::new((base + 2) as usize),
         )
     }
 
     /// Returns the first corner of the face.
     #[inline]
     pub fn corner(&self) -> CornerId {
-        CornerId::new(self.0 * 3)
+        CornerId::new((self.0 * 3) as usize)
     }
 
     #[inline]
     pub(super) fn new(index: usize) -> Self {
-        Self(index)
+        Self(index as u32)
     }
 }
 

--- a/src/mesh/corner_table/mod.rs
+++ b/src/mesh/corner_table/mod.rs
@@ -52,7 +52,7 @@ impl<S: RealNumber> CornerTable<S> {
     fn validate_topology(&self) -> bool {
         for corner_idx in 0..self.corners.len() {
             let corner = &self.corners[corner_idx];
-            let corner_id = CornerId::new(corner_idx);
+            let corner_id = CornerId::new(corner_idx as u32);
 
             if corner.is_deleted() {
                 continue;
@@ -83,7 +83,7 @@ impl<S: RealNumber> CornerTable<S> {
             }
 
             let corner = &self[vertex.corner()];
-            let valid = !corner.is_deleted() && corner.vertex() == VertexId::new(vertex_idx);
+            let valid = !corner.is_deleted() && corner.vertex() == VertexId::new(vertex_idx as u32);
 
             if !valid {
                 return false;

--- a/src/mesh/corner_table/traversal.rs
+++ b/src/mesh/corner_table/traversal.rs
@@ -9,7 +9,7 @@ impl<S: RealNumber> CornerTable<S> {
             .enumerate()
             .step_by(3)
             .filter(|(_, corner)| !corner.is_deleted())
-            .map(|(index, _)| FaceId::new(index / 3))
+            .map(|(index, _)| FaceId::new((index / 3) as u32))
     }
 
     #[inline]
@@ -17,7 +17,7 @@ impl<S: RealNumber> CornerTable<S> {
         self.vertices.iter()
             .enumerate()
             .filter(|(_, vertex)| !vertex.is_deleted())
-            .map(|(index, _)| VertexId::new(index))
+            .map(|(index, _)| VertexId::new(index as u32))
     }
 
     #[inline]
@@ -25,7 +25,7 @@ impl<S: RealNumber> CornerTable<S> {
         self.corners.iter()
             .enumerate()
             .filter(|(_, corner)| !corner.is_deleted())
-            .map(|(index, _)| EdgeId::new(CornerId::new(index)))
+            .map(|(index, _)| EdgeId::new(CornerId::new(index as u32)))
     }
 
     #[inline]

--- a/src/mesh/corner_table/vertex.rs
+++ b/src/mesh/corner_table/vertex.rs
@@ -11,8 +11,8 @@ pub struct VertexId(u32);
 
 impl VertexId {
     #[inline]
-    pub(super) fn new(index: usize) -> Self {
-        Self(index as u32)
+    pub(super) fn new(index: u32) -> Self {
+        Self(index)
     }
 
     #[inline]

--- a/src/mesh/corner_table/vertex.rs
+++ b/src/mesh/corner_table/vertex.rs
@@ -7,17 +7,17 @@ use std::{
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct VertexId(usize);
+pub struct VertexId(u32);
 
 impl VertexId {
     #[inline]
     pub(super) fn new(index: usize) -> Self {
-        Self(index)
+        Self(index as u32)
     }
 
     #[inline]
     pub(super) fn index(&self) -> usize {
-        self.0
+        self.0 as usize
     }
 }
 
@@ -91,14 +91,14 @@ impl<S: RealNumber> Index<VertexId> for CornerTable<S> {
 
     #[inline]
     fn index(&self, index: VertexId) -> &Self::Output {
-        &self.vertices[index.0]
+        &self.vertices[index.0 as usize]
     }
 }
 
 impl<S: RealNumber> IndexMut<VertexId> for CornerTable<S> {
     #[inline]
     fn index_mut(&mut self, index: VertexId) -> &mut Self::Output {
-        &mut self.vertices[index.0]
+        &mut self.vertices[index.0 as usize]
     }
 }
 


### PR DESCRIPTION
Changes internal index type to `u32` to decrease mesh size and improve cache hits