### PR TITLE
Made the library accept any vertex type as input

### DIFF
--- a/src/mesh/corner_table/vertex.rs
+++ b/src/mesh/corner_table/vertex.rs
@@ -128,6 +128,12 @@ impl<S: RealNumber> CornerTable<S> {
         self[vertex].position()
     }
 
+    #[inline]
+    /// Returns a vertex as any type that implements `From<[S; 3]>`
+    pub fn vertex_position_generic<V: From<[S; 3]>>(&self, vertex: VertexId) -> V {
+        V::from(self.vertex_position(vertex).clone().into())
+    }
+
     pub fn vertex_normal(&self, vertex: VertexId) -> Option<Vec3<S>> {
         let mut sum = Vec3::zeros();
 

--- a/src/mesh/traits.rs
+++ b/src/mesh/traits.rs
@@ -17,21 +17,41 @@ pub trait Triangles {
     fn triangles(&self) -> impl Iterator<Item = Triangle3<Self::Scalar>>;
 }
 
+mod sealed {
+    pub trait IndexType {}
+
+    // Zero-cost conversions to usize (on 32/64-bit platforms)
+    // `I.try_into().unwrap()` is optimized as `I as usize`
+    impl IndexType for usize {}
+    impl IndexType for u32 {}
+    impl IndexType for u16 {}
+    // Runtime-checked conversion - included for ergonomics since i32 is the
+    // default integer literal type in Rust. Negative values will panic.
+    impl IndexType for i32 {}
+}
+
 /// Triangular mesh
 pub trait FromIndexed {
     type Scalar: RealNumber;
 
     /// Creates mesh from vertices and face indices
-    fn from_vertex_and_face_iters(
-        vertices: impl Iterator<Item = Vec3<Self::Scalar>>,
-        faces: impl Iterator<Item = usize>,
-    ) -> Self;
+    fn from_vertex_and_face_iters<V, I>(
+        vertices: impl Iterator<Item = V>,
+        faces: impl Iterator<Item = I>,
+    ) -> Self
+    where
+        V: Into<[Self::Scalar; 3]>,
+        I: TryInto<usize> + sealed::IndexType,
+        I::Error: std::fmt::Debug;
 
     /// Creates mesh from vertices and face indices saved in slices
     #[inline]
-    fn from_vertex_and_face_slices(vertices: &[Vec3<Self::Scalar>], faces: &[usize]) -> Self
+    fn from_vertex_and_face_slices<V, I>(vertices: &[V], faces: &[I]) -> Self
     where
         Self: Sized,
+        V: Clone + Into<[Self::Scalar; 3]>,
+        I: Copy + TryInto<usize> + sealed::IndexType,
+        I::Error: std::fmt::Debug,
     {
         Self::from_vertex_and_face_iters(vertices.iter().cloned(), faces.iter().cloned())
     }

--- a/src/voxel/meshing/marching_cubes.rs
+++ b/src/voxel/meshing/marching_cubes.rs
@@ -40,7 +40,7 @@ impl MarchingCubesMesher {
         self
     }
 
-    pub fn mesh(&mut self, sdf: &Volume) -> Vec<Vec3f> {
+    fn _mesh(&mut self, sdf: &Volume) {
         self.clear();
 
         let mut compute_intersections = ComputeEdgeIntersections {
@@ -58,8 +58,20 @@ impl MarchingCubesMesher {
         };
 
         sdf.grid().visit_leafs(&mut cubes_visitor);
+    }
 
+    pub fn mesh(&mut self, sdf: &Volume) -> Vec<Vec3f> {
+        self._mesh(sdf);
         self.vertices.clone()
+    }
+
+    /// A helper method that does the same as the `mesh()` method, but returns the data in any
+    /// (f32 based) vector type the user requires
+    // This method could be optimized more if `self.vertices` were created in the desired format
+    // in the first place.
+    pub fn mesh_generic<V: From<[f32; 3]>>(&mut self, sdf: &Volume) -> Vec<V> {
+        self._mesh(sdf);
+        self.vertices.iter().map(|v| V::from(v.clone().into())).collect()
     }
 
     fn clear(&mut self) {


### PR DESCRIPTION
## Problem
Users working with different vector libraries (glam, cgmath, different nalgebra versions) are forced to manually convert their vertex data to the library's specific vector type before calling `from_vertex_and_face_slices()`. This creates friction and couples user code to the library's internal dependencies.

## Solution
`PolygonSoup` and `CornerTable` now accept any vertex type implementing `Into<[Scalar; 3]>` and can output any type implementing `From<[Scalar; 3]>`. This enables seamless interoperability with:
- Different nalgebra versions
- glam, cgmath, and other vector libraries  
- Custom vector types

The implementation uses `[Scalar; 3]` as an intermediate representation, which acts as a universal interface between vector libraries. This approach provides zero-cost abstraction when the input/output types match the library's internal representation, with minimal overhead for type conversions.

## Changes
- Extended input methods to accept generic vertex types via `Into<[Scalar; 3]>` bounds
- The index type is now also generic (e.g u16, u32 or usize)
- Added generic output methods returning user-specified types via `From<[Scalar; 3]>` bounds
- Added `MarchingCubesMesher::mesh_generic()` for flexible mesh type conversion
- Added `CornerTable::vertex_position_generic()` for type-flexible vertex access

## Notes
- Performance impact is minimal: conversions optimize to NOPs when types match, simple memory operations otherwise
- The `mesh_generic()` method currently creates an intermediate `Vec` during conversion - this could potentially be optimized if the desired type were used in the first place.
- Consider whether `vertex_position()` should return by-value rather than by-reference to eliminate the need for separate generic method (`vertex_position_generic()`)
- I only touched on the interfaces used by my application (using remesh, decimate and boolean) there might be other areas where similar fixes may be applicable)
- `try_into::<usize>(u32).unwrap()` optimizes down to `u32 as usize` on 64 bit systems [godbolt](https://godbolt.org/z/PYdvK6ToW)
- I will squash the commits when done 